### PR TITLE
[UI/#22] 상태칩 공통 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapDeadlineChip.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapDeadlineChip.kt
@@ -1,0 +1,65 @@
+package com.haphap.app.core.designsystem.component.chip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.haphap.app.core.designsystem.theme.HapHapTheme
+
+/**
+ * 마감(디데이) 상태칩 공통 컴포넌트입니다.
+ *
+ * "{전형명} 발표 D-{디데이}" 형태로 표시되며,
+ * 전형명 부분은 gray600, 디데이 부분은 primary500으로 표시됩니다.
+ *
+ * @param stage 전형명 (예: 서류, 최종)
+ * @param dDay 발표까지 남은 일수
+ *
+ */
+@Composable
+fun HapHapDeadlineChip(
+    stage: String,
+    dDay: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .clip(shape = CircleShape)
+            .background(HapHapTheme.colors.white)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "$stage 발표",
+            style = HapHapTheme.typography.caption.m10,
+            color = HapHapTheme.colors.gray600,
+        )
+        Text(
+            text = "D-$dDay",
+            style = HapHapTheme.typography.caption.m10,
+            color = HapHapTheme.colors.primary500,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HapHapDeadlineChipPreview() {
+    HapHapTheme {
+        Row(modifier = Modifier.padding(16.dp)) {
+            HapHapDeadlineChip(
+                stage = "서류",
+                dDay = 2,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
@@ -1,0 +1,77 @@
+package com.haphap.app.core.designsystem.component.chip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.haphap.app.core.designsystem.theme.HapHapTheme
+
+/**
+ * 상태칩 공통 컴포넌트입니다.
+ *
+ * 타입에 따라 텍스트 스타일이 변경되며, 배경은 sub100, 텍스트는 primary500으로 표시됩니다.
+ *
+ * @param text 표시할 텍스트
+ * @param type 칩 타입 (CATEGORY: 직무, STAGE: 전형, COUNT: 인원)
+ *
+ */
+@Composable
+fun HapHapStatusChip(
+    text: String,
+    type: StatusChipType,
+    modifier: Modifier = Modifier,
+) {
+    val textStyle: TextStyle = when (type) {
+        StatusChipType.CATEGORY -> HapHapTheme.typography.caption.sb10
+        StatusChipType.STAGE -> HapHapTheme.typography.caption.m12
+        StatusChipType.COUNT -> HapHapTheme.typography.body.sb14
+    }
+
+    Row(
+        modifier = modifier
+            .clip(shape = CircleShape)
+            .background(HapHapTheme.colors.sub100)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = textStyle,
+            color = HapHapTheme.colors.primary500,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HapHapStatusChipPreview() {
+    HapHapTheme {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            HapHapStatusChip(
+                text = "개발",
+                type = StatusChipType.CATEGORY,
+            )
+            HapHapStatusChip(
+                text = "서류",
+                type = StatusChipType.STAGE,
+            )
+            HapHapStatusChip(
+                text = "+32명",
+                type = StatusChipType.COUNT,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
@@ -36,20 +36,15 @@ fun HapHapStatusChip(
         StatusChipType.COUNT -> HapHapTheme.typography.body.sb14
     }
 
-    Row(
+    Text(
+        text = text,
+        style = textStyle,
+        color = HapHapTheme.colors.primary500,
         modifier = modifier
             .clip(shape = CircleShape)
             .background(HapHapTheme.colors.sub100)
-            .padding(horizontal = 6.dp, vertical = 2.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = text,
-            style = textStyle,
-            color = HapHapTheme.colors.primary500,
-        )
-    }
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/component/chip/HapHapStatusChip.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.haphap.app.core.designsystem.theme.HapHapTheme
+import com.haphap.app.core.designsystem.type.StatusChipType
 
 /**
  * 상태칩 공통 컴포넌트입니다.

--- a/app/src/main/java/com/haphap/app/core/designsystem/component/chip/StatusChipType.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/component/chip/StatusChipType.kt
@@ -1,0 +1,7 @@
+package com.haphap.app.core.designsystem.component.chip
+
+enum class StatusChipType {
+    CATEGORY,
+    STAGE,
+    COUNT,
+}

--- a/app/src/main/java/com/haphap/app/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/theme/Type.kt
@@ -80,6 +80,7 @@ data class CaptionStyle(
     val r12: TextStyle = haphapTextStyle(weight = FontWeight.Normal, size = 12),
     val r11: TextStyle = haphapTextStyle(weight = FontWeight.Normal, size = 11),
     val sb10: TextStyle = haphapTextStyle(weight = FontWeight.SemiBold, size = 10, lineHeight= 1.3.em),
+    val m10: TextStyle = haphapTextStyle(weight = FontWeight.Medium, size =10, lineHeight= 1.3.em),
     val r10: TextStyle = haphapTextStyle(weight = FontWeight.Normal, size = 10),
 )
 
@@ -111,6 +112,7 @@ private fun TypographyPreview() {
             Text("Caption b12", style = HapHapTheme.typography.caption.b12)
             Text("Caption r11", style = HapHapTheme.typography.caption.r11)
             Text("Caption sb10", style = HapHapTheme.typography.caption.sb10)
+            Text("Caption m10", style = HapHapTheme.typography.caption.m10)
             Text("Caption r10", style = HapHapTheme.typography.caption.r10)
         }
     }

--- a/app/src/main/java/com/haphap/app/core/designsystem/type/StatusChipType.kt
+++ b/app/src/main/java/com/haphap/app/core/designsystem/type/StatusChipType.kt
@@ -1,4 +1,4 @@
-package com.haphap.app.core.designsystem.component.chip
+package com.haphap.app.core.designsystem.type
 
 enum class StatusChipType {
     CATEGORY,


### PR DESCRIPTION
<!-- 제목 : [유형/#이슈번호] 작업 내용 (ex. "[UI/#6] 홈화면 구현") -->

## Related issue 🛠
<!-- 관련된 이슈 번호를 적어주셔야 pr이 머지될 때 해당 이슈가 자동으로 닫힙니다 -->
- closed #22 

## Work Description ✏️
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->
- 상태칩 공통 컴포넌트 구현했습니다


## Screenshot 📸
<img width="502" height="225" alt="image" src="https://github.com/user-attachments/assets/416bad23-79dc-4ce2-ba9a-c530a19d52d2" />
<img width="458" height="253" alt="image" src="https://github.com/user-attachments/assets/a756080c-252c-401c-866b-06389ff2e5af" />



## Uncompleted Tasks 😅
- N/A


## To Reviewers 📢
- 일반 상태칩과 D-DAY 칩을 컴포넌트로 분리한 이유
: 두 컴포넌트는 UI 구조 자체가 달라 하나로 묶을 경우 분기 처리가 복잡해질 수 있다고 생각했습니다
일반 상태칩은 단일 텍스트 기반인데 반해 D-DAY 칩은 stage + dDay 두 텍스트 조합으로 구성되어 있어 사용 목적에 맞게 분리했습니다
- D-DAY 칩 파라미터를 stage와 dDay로 분리한 이유
: 서버에서는 전형명과 남은 일수만 내려주고, 각 텍스트의 색상도 다르게 적용되어야 하는 구조라 하나의 문자열로 합치기보다 각각 분리해서 UI에서 조합하는 방식으로 구현했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “마감” 정보를 보여주는 새 칩 UI(단계, D-day)를 추가했습니다.
  * 상태/카테고리/단계/개수에 따라 텍스트 스타일이 달라지는 상태 칩 UI를 추가했습니다.
  * 두 칩의 미리보기 화면을 함께 제공해 시각 확인이 쉬워졌습니다.
* **Style**
  * 타이포그래피 미리보기에서 `caption m10` 항목이 추가되어 디자인 점검이 더 편리해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->