### PR TITLE
[FEAT/#37] 스플래시 구현

### DIFF
--- a/app/src/main/java/com/haphap/app/presentation/main/MainAppState.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainAppState.kt
@@ -16,6 +16,7 @@ import com.haphap.app.presentation.job.navigation.navigateToJob
 import com.haphap.app.presentation.main.component.MainTab
 import com.haphap.app.presentation.mypage.navigation.navigateToMyPage
 import com.haphap.app.presentation.register.navigation.navigateToRegister
+import com.haphap.app.presentation.splash.navigation.Splash
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -27,7 +28,7 @@ class MainAppState(
     val navController: NavHostController,
     coroutineScope: CoroutineScope,
 ) {
-    val startDestination: Route = Login
+    val startDestination: Route = Splash
 
     private val currentDestination = navController.currentBackStackEntryFlow
         .map { it.destination }

--- a/app/src/main/java/com/haphap/app/presentation/main/MainAppState.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainAppState.kt
@@ -9,7 +9,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.haphap.app.core.navigation.Route
-import com.haphap.app.presentation.auth.navigation.Login
 import com.haphap.app.presentation.calendar.navigation.navigateToCalendar
 import com.haphap.app.presentation.home.navigation.navigateToHome
 import com.haphap.app.presentation.job.navigation.navigateToJob

--- a/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
@@ -8,7 +8,6 @@ import com.haphap.app.core.navigation.Route
 import com.haphap.app.presentation.auth.navigation.Login
 import com.haphap.app.presentation.auth.navigation.SignUpComplete
 import com.haphap.app.presentation.auth.navigation.authGraph
-import com.haphap.app.presentation.auth.navigation.navigateToLogin
 import com.haphap.app.presentation.auth.navigation.navigateToSignUpComplete
 import com.haphap.app.presentation.auth.navigation.signUpCompleteGraph
 import com.haphap.app.presentation.calendar.navigation.calendarGraph
@@ -17,7 +16,6 @@ import com.haphap.app.presentation.home.navigation.navigateToHome
 import com.haphap.app.presentation.job.navigation.jobGraph
 import com.haphap.app.presentation.mypage.navigation.myPageGraph
 import com.haphap.app.presentation.register.navigation.registerGraph
-import com.haphap.app.presentation.splash.navigation.Splash
 import com.haphap.app.presentation.splash.navigation.splashGraph
 
 @Composable
@@ -34,22 +32,7 @@ fun MainNavHost(
     ) {
         splashGraph(
             innerPadding = innerPadding,
-            navigateToHome = {
-                navController.navigateToHome(
-                    navOptions = navOptions {
-                        popUpTo<Splash> {inclusive = true}
-                        launchSingleTop = true
-                    }
-                )
-            },
-            navigateToLogin = {
-                navController.navigateToLogin(
-                    navOptions = navOptions {
-                        popUpTo<Splash> {inclusive = true}
-                        launchSingleTop = true
-                    }
-                )
-            }
+            navController = navController,
         )
 
         authGraph(

--- a/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
@@ -8,6 +8,7 @@ import com.haphap.app.core.navigation.Route
 import com.haphap.app.presentation.auth.navigation.Login
 import com.haphap.app.presentation.auth.navigation.SignUpComplete
 import com.haphap.app.presentation.auth.navigation.authGraph
+import com.haphap.app.presentation.auth.navigation.navigateToLogin
 import com.haphap.app.presentation.auth.navigation.navigateToSignUpComplete
 import com.haphap.app.presentation.auth.navigation.signUpCompleteGraph
 import com.haphap.app.presentation.calendar.navigation.calendarGraph
@@ -16,6 +17,8 @@ import com.haphap.app.presentation.home.navigation.navigateToHome
 import com.haphap.app.presentation.job.navigation.jobGraph
 import com.haphap.app.presentation.mypage.navigation.myPageGraph
 import com.haphap.app.presentation.register.navigation.registerGraph
+import com.haphap.app.presentation.splash.navigation.Splash
+import com.haphap.app.presentation.splash.navigation.splashGraph
 
 @Composable
 fun MainNavHost(
@@ -29,6 +32,26 @@ fun MainNavHost(
         navController = navController,
         startDestination = startDestination,
     ) {
+        splashGraph(
+            innerPadding = innerPadding,
+            navigateToHome = {
+                navController.navigateToHome(
+                    navOptions = navOptions {
+                        popUpTo<Splash> {inclusive = true}
+                        launchSingleTop = true
+                    }
+                )
+            },
+            navigateToLogin = {
+                navController.navigateToLogin(
+                    navOptions = navOptions {
+                        popUpTo<Splash> {inclusive = true}
+                        launchSingleTop = true
+                    }
+                )
+            }
+        )
+
         authGraph(
             innerPadding = innerPadding,
             navigateToHome = {

--- a/app/src/main/java/com/haphap/app/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/SplashScreen.kt
@@ -10,13 +10,37 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.haphap.app.R
 import com.haphap.app.core.designsystem.theme.HapHapTheme
+
+@Composable
+fun SplashRoute(
+    navigateToHome: () -> Unit,
+    navigateToLogin: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SplashViewModel = hiltViewModel(),
+) {
+    val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle()
+
+    LaunchedEffect(isLoggedIn) {
+        when (isLoggedIn) {
+            true -> navigateToHome()
+            false -> navigateToLogin()
+            null -> Unit
+        }
+    }
+
+    SplashScreen(modifier = modifier)
+}
 
 @Composable
 fun SplashScreen(

--- a/app/src/main/java/com/haphap/app/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/SplashScreen.kt
@@ -1,0 +1,64 @@
+package com.haphap.app.presentation.splash
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.haphap.app.R
+import com.haphap.app.core.designsystem.theme.HapHapTheme
+
+@Composable
+fun SplashScreen(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(HapHapTheme.colors.white)
+            .padding(bottom = 28.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        Image(
+            painter = painterResource(R.drawable.img_logo),
+            contentDescription = null,
+            modifier = Modifier.size(width = 121.dp, height = 129.dp),
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Image(
+            painter = painterResource(R.drawable.img_text_logo),
+            contentDescription = null,
+            modifier = Modifier.size(width = 144.dp, height = 22.dp),
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "합격 발표가 움직이는 순간",
+            style = HapHapTheme.typography.body.r14,
+            color = HapHapTheme.colors.gray400,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SplashScreenPreview() {
+    HapHapTheme {
+        SplashScreen()
+    }
+}

--- a/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
@@ -1,0 +1,36 @@
+package com.haphap.app.presentation.splash
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.haphap.app.data.local.datasource.api.LocalTokenDataSource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val localTokenDataSource: LocalTokenDataSource
+) : ViewModel() {
+    private val _isLoggedIn = MutableStateFlow<Boolean?>(null)
+    val isLoggedIn: StateFlow<Boolean?> = _isLoggedIn
+
+    init {
+        checkLoginState()
+    }
+
+    private fun checkLoginState() {
+        viewModelScope.launch {
+            val tokenDelayed = async { localTokenDataSource.getAccessToken() }
+            val minDelay = async { delay(2000) }
+
+            val accessToken = tokenDelayed.await()
+            minDelay.await()
+
+            _isLoggedIn.value = !accessToken.isNullOrBlank()
+        }
+    }
+}

--- a/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
@@ -24,13 +24,16 @@ class SplashViewModel @Inject constructor(
 
     private fun checkLoginState() {
         viewModelScope.launch {
-            val tokenDelayed = async { localTokenDataSource.getAccessToken() }
-            val minDelay = async { delay(2000) }
+            val tokenDelay = async {
+                runCatching { localTokenDataSource.getAccessToken() }.getOrNull()
+            }
+            delay(MIN_SPLASH_DELAY_MS)
 
-            val accessToken = tokenDelayed.await()
-            minDelay.await()
-
+            val accessToken = tokenDelay.await()
             _isLoggedIn.value = !accessToken.isNullOrBlank()
         }
+    }
+    companion object {
+        private const val MIN_SPLASH_DELAY_MS = 2000L
     }
 }

--- a/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
@@ -2,6 +2,7 @@ package com.haphap.app.presentation.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.haphap.app.core.util.suspendRunCatching
 import com.haphap.app.data.local.datasource.api.LocalTokenDataSource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
@@ -25,7 +26,7 @@ class SplashViewModel @Inject constructor(
     private fun checkLoginState() {
         viewModelScope.launch {
             val tokenDelay = async {
-                runCatching { localTokenDataSource.getAccessToken() }.getOrNull()
+                suspendRunCatching { localTokenDataSource.getAccessToken() }.getOrNull()
             }
             delay(MIN_SPLASH_DELAY_MS)
 

--- a/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/SplashViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
-class LoginViewModel @Inject constructor(
+class SplashViewModel @Inject constructor(
     private val localTokenDataSource: LocalTokenDataSource
 ) : ViewModel() {
     private val _isLoggedIn = MutableStateFlow<Boolean?>(null)

--- a/app/src/main/java/com/haphap/app/presentation/splash/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/navigation/SplashNavigation.kt
@@ -7,7 +7,10 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navOptions
 import com.haphap.app.core.navigation.Route
+import com.haphap.app.presentation.auth.navigation.navigateToLogin
+import com.haphap.app.presentation.home.navigation.navigateToHome
 import com.haphap.app.presentation.splash.SplashRoute
 import kotlinx.serialization.Serializable
 
@@ -17,13 +20,24 @@ fun NavController.navigateToSplash(
 
 fun NavGraphBuilder.splashGraph(
     innerPadding: PaddingValues,
-    navigateToHome: () -> Unit,
-    navigateToLogin: () -> Unit,
+    navController: NavController,
 ) {
     composable<Splash> {
         SplashRoute (
-            navigateToHome = navigateToHome,
-            navigateToLogin = navigateToLogin,
+            navigateToHome = {
+                navController.navigateToHome(
+                navOptions = navOptions {
+                    popUpTo<Splash> {inclusive = true}
+                    launchSingleTop = true
+                })
+            },
+            navigateToLogin = {
+                navController.navigateToLogin(
+                navOptions = navOptions {
+                    popUpTo<Splash> {inclusive = true}
+                    launchSingleTop = true
+                })
+            },
             modifier = Modifier.padding(innerPadding),
         )
     }

--- a/app/src/main/java/com/haphap/app/presentation/splash/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/navigation/SplashNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.haphap.app.core.navigation.Route
 import com.haphap.app.presentation.splash.SplashRoute
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/haphap/app/presentation/splash/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/splash/navigation/SplashNavigation.kt
@@ -1,0 +1,32 @@
+package com.haphap.app.presentation.splash.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.haphap.app.presentation.splash.SplashRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigateToSplash(
+    navOptions: NavOptions? = null
+) = navigate(Splash, navOptions)
+
+fun NavGraphBuilder.splashGraph(
+    innerPadding: PaddingValues,
+    navigateToHome: () -> Unit,
+    navigateToLogin: () -> Unit,
+) {
+    composable<Splash> {
+        SplashRoute (
+            navigateToHome = navigateToHome,
+            navigateToLogin = navigateToLogin,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@Serializable
+data object Splash : Route

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.HapHap" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.HapHap" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowBackground">@color/white</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
<!-- 제목 : [유형/#이슈번호] 작업 내용 (ex. "[UI/#6] 홈화면 구현") -->

## Related issue 🛠
<!-- 관련된 이슈 번호를 적어주셔야 pr이 머지될 때 해당 이슈가 자동으로 닫힙니다 -->
- closed #37 

## Work Description ✏️
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->
- 스플래시 화면 UI 구현
- startDestination으로 지정
- 안드로이드 기본 스플래시 삭제


## Screenshot 📸
| 로그인 토큰 無 | 로그인 토큰 有 |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/62f4eadf-1488-4ae5-aaea-5e0665f6cecb" width="360" height="1080" controls></video> | <video src="https://github.com/user-attachments/assets/a01ca42f-b9a5-4900-ba02-4d31683f9b78" width="360" height="1080" controls></video> | 

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
스플래시 야호~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 앱 시작 시 스플래시 화면이 추가되었습니다.
  * 저장된 로그인 상태에 따라 홈 또는 로그인으로 자동 이동합니다.
  * 스플래시 화면에 앱 로고와 안내 문구를 표시합니다.
* **Bug Fixes**
  * 스플래시에서 이동할 때 뒤로 가기 동작이 올바르게 정리되어, 불필요한 화면이 기록되지 않도록 개선했습니다.
  * 동일 화면의 중복 생성/중복 전환을 방지하도록 내비게이션 동작을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->