### PR TITLE
[FEAT/#49] Response data null 처리

### DIFF
--- a/app/src/main/java/com/haphap/app/data/remote/dto/BaseResponse.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/dto/BaseResponse.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 private const val HTTP_OK = 200
 private const val HTTP_CREATED = 201
-private const val HTTP_DATA_NULL = 204
+private const val HTTP_NO_CONTENT = 204
 
 @Serializable
 data class BaseResponse<T>(
@@ -20,6 +20,11 @@ data class BaseResponse<T>(
 )
 
 fun <T> BaseResponse<T>.requireData(): T {
-    if (status != HTTP_OK && status != HTTP_CREATED && status != HTTP_DATA_NULL) throw IllegalStateException("API request failed.")
+    if (status != HTTP_OK && status != HTTP_CREATED) throw IllegalStateException("API request failed.")
     return data ?: throw IllegalStateException("Successful response but data was null.")
+}
+
+fun <T> BaseResponse<T>.requireNoContent(): T? {
+    if (status != HTTP_NO_CONTENT) throw IllegalStateException("API request failed.")
+    return data
 }

--- a/app/src/main/java/com/haphap/app/data/remote/dto/BaseResponse.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/dto/BaseResponse.kt
@@ -3,6 +3,10 @@ package com.haphap.app.data.remote.dto
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+private const val HTTP_OK = 200
+private const val HTTP_CREATED = 201
+private const val HTTP_DATA_NULL = 204
+
 @Serializable
 data class BaseResponse<T>(
     @SerialName("status")
@@ -14,3 +18,8 @@ data class BaseResponse<T>(
     @SerialName("data")
     val data: T? = null,
 )
+
+fun <T> BaseResponse<T>.requireData(): T {
+    if (status != HTTP_OK && status != HTTP_CREATED && status != HTTP_DATA_NULL) throw IllegalStateException("API request failed.")
+    return data ?: throw IllegalStateException("Successful response but data was null.")
+}

--- a/app/src/main/java/com/haphap/app/data/remote/dto/BaseResponse.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/dto/BaseResponse.kt
@@ -19,12 +19,12 @@ data class BaseResponse<T>(
     val data: T? = null,
 )
 
-fun <T> BaseResponse<T>.requireData(): T {
-    if (status != HTTP_OK && status != HTTP_CREATED) throw IllegalStateException("API request failed.")
-    return data ?: throw IllegalStateException("Successful response but data was null.")
+fun <T> BaseResponse<T>.checkData(): T {
+    if (status != HTTP_OK && status != HTTP_CREATED) throw IllegalStateException("Successful response but data was null.")
+    return data ?: throw IllegalStateException("API request failed")
 }
 
-fun <T> BaseResponse<T>.requireNoContent(): T? {
-    if (status != HTTP_NO_CONTENT) throw IllegalStateException("API request failed.")
+fun <T> BaseResponse<T>.checkNullData(): T? {
+    if (status != HTTP_NO_CONTENT) throw IllegalStateException("API request failed")
     return data
 }

--- a/app/src/main/java/com/haphap/app/data/repository/impl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/auth/AuthRepositoryImpl.kt
@@ -6,7 +6,7 @@ import com.haphap.app.data.mapper.auth.toModel
 import com.haphap.app.data.model.auth.KakaoLoginModel
 import com.haphap.app.data.remote.datasource.api.auth.AuthDataSource
 import com.haphap.app.data.remote.dto.auth.KakaoLoginRequestDto
-import com.haphap.app.data.remote.dto.requireData
+import com.haphap.app.data.remote.dto.checkData
 import com.haphap.app.data.repository.api.auth.AuthRepository
 import jakarta.inject.Inject
 
@@ -16,7 +16,7 @@ class AuthRepositoryImpl @Inject constructor(
 ): AuthRepository {
     override suspend fun postKakaoLogin(accessToken: String): Result<KakaoLoginModel> =
         suspendRunCatching {
-            val response = authDataSource.postKakaoLogin(KakaoLoginRequestDto(accessToken)).requireData()
+            val response = authDataSource.postKakaoLogin(KakaoLoginRequestDto(accessToken)).checkData()
 
 
             localTokenDataSource.setAccessToken(response.accessToken)

--- a/app/src/main/java/com/haphap/app/data/repository/impl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/auth/AuthRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.haphap.app.data.mapper.auth.toModel
 import com.haphap.app.data.model.auth.KakaoLoginModel
 import com.haphap.app.data.remote.datasource.api.auth.AuthDataSource
 import com.haphap.app.data.remote.dto.auth.KakaoLoginRequestDto
+import com.haphap.app.data.remote.dto.requireData
 import com.haphap.app.data.repository.api.auth.AuthRepository
 import jakarta.inject.Inject
 
@@ -15,12 +16,12 @@ class AuthRepositoryImpl @Inject constructor(
 ): AuthRepository {
     override suspend fun postKakaoLogin(accessToken: String): Result<KakaoLoginModel> =
         suspendRunCatching {
-            val response = authDataSource.postKakaoLogin(KakaoLoginRequestDto(accessToken))
-            val data = response.data ?: throw IllegalStateException("response data is null")
+            val response = authDataSource.postKakaoLogin(KakaoLoginRequestDto(accessToken)).requireData()
 
-            localTokenDataSource.setAccessToken(data.accessToken)
-            localTokenDataSource.setRefreshToken(data.refreshToken)
 
-            data.toModel()
+            localTokenDataSource.setAccessToken(response.accessToken)
+            localTokenDataSource.setRefreshToken(response.refreshToken)
+
+            response.toModel()
         }
 }


### PR DESCRIPTION
<!-- 제목 : [유형/#이슈번호] 작업 내용 (ex. "[UI/#6] 홈화면 구현") -->

## Related issue 🛠
<!-- 관련된 이슈 번호를 적어주셔야 pr이 머지될 때 해당 이슈가 자동으로 닫힙니다 -->
- closed #49

## Work Description ✏️
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->
- requireData 만들었습니다.


## Screenshot 📸
- N/A


## Uncompleted Tasks 😅
- N/A


## To Reviewers 📢
- AuthRepositoryImpl 수정해두었으니 요렇게 사용하시면 됩니다 참고 부탁띠니

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 응답 상태 코드 기준으로 데이터 유효성을 더 엄격히 검증해 누락되거나 비정상인 응답을 만났을 때 명확하게 오류를 처리하도록 개선했습니다.
  * 카카오 로그인 처리 시 성공으로 간주되더라도 응답 데이터가 없으면 사용하지 않고, 올바르게 실패 처리되도록 동작을 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->