### PR TITLE
[Feat/#89] calendar detail nav

### DIFF
--- a/app/src/main/java/com/haphap/app/data/joblist/JobListDataSourceModule.kt
+++ b/app/src/main/java/com/haphap/app/data/joblist/JobListDataSourceModule.kt
@@ -1,0 +1,19 @@
+package com.haphap.app.data.joblist
+
+import com.haphap.app.data.remote.datasource.api.joblist.JobListDataSource
+import com.haphap.app.data.remote.datasource.impl.joblist.JobListDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class JobListDataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindJobListDataSource(
+        jobListDataSourceImpl: JobListDataSourceImpl
+    ): JobListDataSource
+}

--- a/app/src/main/java/com/haphap/app/data/joblist/JobListRepositoryModule.kt
+++ b/app/src/main/java/com/haphap/app/data/joblist/JobListRepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.haphap.app.data.joblist
+
+import com.haphap.app.data.repository.api.JobListRepository
+import com.haphap.app.data.repository.impl.JobListRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class JobListRepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindJobListRepository(
+        jobListRepositoryImpl: JobListRepositoryImpl
+    ): JobListRepository
+}

--- a/app/src/main/java/com/haphap/app/data/joblist/JobListServiceModule.kt
+++ b/app/src/main/java/com/haphap/app/data/joblist/JobListServiceModule.kt
@@ -1,0 +1,21 @@
+package com.haphap.app.data.joblist
+
+import com.haphap.app.data.remote.service.JobListService
+import com.haphap.app.data.remote.service.home.HomeService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object JobListServiceModule {
+    @Provides
+    @Singleton
+    fun provideJobListService(
+        retrofit: Retrofit
+    ): JobListService = retrofit.create()
+}

--- a/app/src/main/java/com/haphap/app/data/mapper/joblist/JobListMapper.kt
+++ b/app/src/main/java/com/haphap/app/data/mapper/joblist/JobListMapper.kt
@@ -1,0 +1,18 @@
+package com.haphap.app.data.mapper.joblist
+
+import com.haphap.app.data.model.list.JobItemModel
+import com.haphap.app.data.remote.dto.joblist.JobItemDto
+import com.haphap.app.data.remote.dto.joblist.JobListResponseDto
+
+fun JobListResponseDto.toModel(): List<JobItemModel> = postings.map { it.toModel() }
+
+private fun JobItemDto.toModel(): JobItemModel =
+    JobItemModel(
+        id = id,
+        imageUrl = imageUrl,
+        category = category,
+        stage = nextStage ?: "null",
+        dDay = daysUntilNextStage ?: 0,
+        title = companyName,
+        content = title,
+    )

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/api/detail/JobDetailDataSource.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/api/detail/JobDetailDataSource.kt
@@ -18,6 +18,4 @@ interface JobDetailDataSource {
     suspend fun setAlarms(postingId: Int): BaseResponse<Unit>
 
     suspend fun deleteAlarms(postingId: Int): BaseResponse<Unit>
-
-    suspend fun recordView(postingId: Int)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/api/joblist/JobListDataSource.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/api/joblist/JobListDataSource.kt
@@ -1,0 +1,12 @@
+package com.haphap.app.data.remote.datasource.api.joblist
+
+import com.haphap.app.data.remote.dto.BaseResponse
+import com.haphap.app.data.remote.dto.home.HomeAnnouncementsResponseDto
+import com.haphap.app.data.remote.dto.home.HomeBannerListDto
+import com.haphap.app.data.remote.dto.home.HomePostingsResponseDto
+import com.haphap.app.data.remote.dto.home.HomeTodayResponseDto
+import com.haphap.app.data.remote.dto.joblist.JobListResponseDto
+
+interface JobListDataSource {
+    suspend fun getJobList(category: List<String>?): BaseResponse<JobListResponseDto>
+}

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
@@ -4,4 +4,6 @@ import com.haphap.app.data.remote.dto.BaseResponse
 
 interface ViewCountDataSource {
     suspend fun patchViewCount(postingId: Int): BaseResponse<Unit>
+
+    suspend fun patchRecordView(postingId: Int)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
@@ -5,5 +5,5 @@ import com.haphap.app.data.remote.dto.BaseResponse
 interface ViewCountDataSource {
     suspend fun patchViewCount(postingId: Int): BaseResponse<Unit>
 
-    suspend fun patchRecordView(postingId: Int)
+    suspend fun patchRecordView(postingId: Int): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/impl/detail/JobDetailDataSourceImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/impl/detail/JobDetailDataSourceImpl.kt
@@ -30,7 +30,4 @@ class JobDetailDataSourceImpl @Inject constructor(
 
     override suspend fun deleteAlarms(postingId: Int): BaseResponse<Unit> =
         jobDetailService.deleteAlarms(postingId)
-
-    override suspend fun recordView(postingId: Int) =
-        jobDetailService.recordView(postingId)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/impl/joblist/JobListDataSourceImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/impl/joblist/JobListDataSourceImpl.kt
@@ -1,0 +1,17 @@
+package com.haphap.app.data.remote.datasource.impl.joblist
+
+import com.haphap.app.data.remote.datasource.api.joblist.JobListDataSource
+import com.haphap.app.data.remote.dto.BaseResponse
+import com.haphap.app.data.remote.dto.joblist.JobListResponseDto
+import com.haphap.app.data.remote.service.JobListService
+import jakarta.inject.Inject
+
+class JobListDataSourceImpl @Inject constructor(
+    private val jobListService: JobListService,
+) : JobListDataSource {
+
+    override suspend fun getJobList(category: List<String>?): BaseResponse<JobListResponseDto> {
+        return jobListService.getJobList(category)
+    }
+
+}

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
@@ -11,4 +11,7 @@ class ViewCountDataSourceImpl @Inject constructor(
     override suspend fun patchViewCount(postingId: Int): BaseResponse<Unit> {
         return viewCountService.patchViewCount(postingId)
     }
+
+    override suspend fun patchRecordView(postingId: Int) =
+        viewCountService.patchRecordView(postingId)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
@@ -12,6 +12,6 @@ class ViewCountDataSourceImpl @Inject constructor(
         return viewCountService.patchViewCount(postingId)
     }
 
-    override suspend fun patchRecordView(postingId: Int) =
+    override suspend fun patchRecordView(postingId: Int): BaseResponse<Unit> =
         viewCountService.patchRecordView(postingId)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/dto/joblist/JobListResponseDto.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/dto/joblist/JobListResponseDto.kt
@@ -1,0 +1,28 @@
+package com.haphap.app.data.remote.dto.joblist
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class JobListResponseDto(
+    @SerialName("postings")
+    val postings: List<JobItemDto>,
+)
+
+@Serializable
+data class JobItemDto(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("title")
+    val title: String,
+    @SerialName("companyName")
+    val companyName: String,
+    @SerialName("category")
+    val category: String,
+    @SerialName("nextStage")
+    val nextStage: String?,
+    @SerialName("daysUntilNextStage")
+    val daysUntilNextStage: Int?,
+    @SerialName("imageUrl")
+    val imageUrl: String,
+)

--- a/app/src/main/java/com/haphap/app/data/remote/service/JobListService.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/service/JobListService.kt
@@ -1,0 +1,15 @@
+package com.haphap.app.data.remote.service
+
+import com.haphap.app.data.remote.dto.BaseResponse
+import com.haphap.app.data.remote.dto.joblist.JobListResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface JobListService {
+
+    @GET("api/v1/postings/all")
+    suspend fun getJobList(
+        @Query("category") category: List<String>? = null
+    ): BaseResponse<JobListResponseDto>
+
+}

--- a/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
@@ -13,5 +13,5 @@ interface ViewCountService {
     @PATCH("api/v1/postings/{postingId}/views")
     suspend fun patchRecordView(
         @Path("postingId") postingId: Int,
-    )
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
@@ -9,4 +9,9 @@ interface ViewCountService {
     suspend fun patchViewCount(
         @Path("postingId") postingId: Int,
     ): BaseResponse<Unit>
+
+    @PATCH("api/v1/postings/{postingId}/views")
+    suspend fun patchRecordView(
+        @Path("postingId") postingId: Int,
+    )
 }

--- a/app/src/main/java/com/haphap/app/data/remote/service/detail/JobDetailService.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/service/detail/JobDetailService.kt
@@ -7,7 +7,6 @@ import com.haphap.app.data.remote.dto.detail.JobDetailStageStatisticDto
 import com.haphap.app.data.remote.dto.detail.JobDetailStageStatusListDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -42,9 +41,4 @@ interface JobDetailService {
     suspend fun deleteAlarms(
         @Path("postingId") postingId: Int,
     ): BaseResponse<Unit>
-
-    @PATCH("api/v1/postings/{postingId}/views")
-    suspend fun recordView(
-        @Path("postingId") postingId: Int,
-    )
 }

--- a/app/src/main/java/com/haphap/app/data/repository/api/JobListRepository.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/api/JobListRepository.kt
@@ -1,0 +1,7 @@
+package com.haphap.app.data.repository.api
+
+import com.haphap.app.data.model.list.JobItemModel
+
+interface JobListRepository {
+    suspend fun getJobList(category: List<String>?): Result<List<JobItemModel>>
+}

--- a/app/src/main/java/com/haphap/app/data/repository/api/detail/JobDetailRepository.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/api/detail/JobDetailRepository.kt
@@ -17,6 +17,4 @@ interface JobDetailRepository {
     suspend fun setJobPostingAlarm(postingId: Int): Result<Unit>
 
     suspend fun deleteJobPostingAlarm(postingId: Int): Result<Unit>
-
-    suspend fun recordView(postingId: Int): Result<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/repository/api/viewcount/ViewCountRepository.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/api/viewcount/ViewCountRepository.kt
@@ -2,4 +2,6 @@ package com.haphap.app.data.repository.api.viewcount
 
 interface ViewCountRepository {
     suspend fun patchViewCount(postingId: Int): Result<Unit>
+
+    suspend fun patchRecordView(postingId: Int): Result<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/repository/impl/JobListRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/JobListRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.haphap.app.data.repository.impl
+
+import com.haphap.app.core.util.suspendRunCatching
+import com.haphap.app.data.mapper.joblist.toModel
+import com.haphap.app.data.model.list.JobItemModel
+import com.haphap.app.data.remote.datasource.api.joblist.JobListDataSource
+import com.haphap.app.data.remote.dto.checkData
+import com.haphap.app.data.repository.api.JobListRepository
+import jakarta.inject.Inject
+
+class JobListRepositoryImpl @Inject constructor(
+    private val jobListDataSource: JobListDataSource,
+): JobListRepository {
+
+    override suspend fun getJobList(category: List<String>?): Result<List<JobItemModel>> =
+        suspendRunCatching {
+            jobListDataSource.getJobList(category).checkData().toModel()
+        }
+}

--- a/app/src/main/java/com/haphap/app/data/repository/impl/detail/JobDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/detail/JobDetailRepositoryImpl.kt
@@ -58,9 +58,4 @@ class JobDetailRepositoryImpl @Inject constructor(
             jobDetailDataSource.deleteAlarms(postingId).checkNullData()
             Unit
         }
-
-    override suspend fun recordView(postingId: Int): Result<Unit> =
-        suspendRunCatching {
-            jobDetailDataSource.recordView(postingId)
-        }
 }

--- a/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
@@ -13,4 +13,9 @@ class ViewCountRepositoryImpl @Inject constructor(
         suspendRunCatching {
             viewCountDataSource.patchViewCount(postingId).checkNullData()
         }
+
+    override suspend fun patchRecordView(postingId: Int): Result<Unit> =
+        suspendRunCatching {
+            viewCountDataSource.patchRecordView(postingId)
+        }
 }

--- a/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
@@ -16,6 +16,6 @@ class ViewCountRepositoryImpl @Inject constructor(
 
     override suspend fun patchRecordView(postingId: Int): Result<Unit> =
         suspendRunCatching {
-            viewCountDataSource.patchRecordView(postingId)
+            viewCountDataSource.patchRecordView(postingId).checkNullData()
         }
 }

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarContract.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarContract.kt
@@ -16,6 +16,10 @@ sealed interface CalendarContract {
         val calendarUiState: CalendarUiState<List<CalendarModel>> = CalendarUiState.Idle,
         val calendarPostingsUiState: CalendarUiState<List<CalendarPostingModel>> = CalendarUiState.Idle,
     )
+
+    sealed class SideEffect {
+        data class NavigateToJobDetail(val postingId: Int) : SideEffect()
+    }
 }
 
 sealed interface CalendarUiState<out T> {

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarScreen.kt
@@ -10,15 +10,20 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.haphap.app.core.designsystem.theme.HapHapTheme
 import com.haphap.app.data.model.calendar.CalendarPostingModel
+import com.haphap.app.presentation.calendar.CalendarContract.SideEffect.NavigateToJobDetail
 import com.haphap.app.presentation.calendar.component.CalendarListCardComponent
 import com.haphap.app.presentation.calendar.component.CalendarListCardEmptyComponent
 import com.haphap.app.presentation.calendar.component.HapHapCustomCalendar
@@ -29,15 +34,27 @@ import java.time.YearMonth
 
 @Composable
 fun CalendarRoute(
+    navigateToJobDetail: (Int) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CalendarViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.sideEffect.collect { sideEffect ->
+                when (sideEffect) {
+                    is NavigateToJobDetail -> navigateToJobDetail(sideEffect.postingId)
+                }
+            }
+        }
+    }
 
     CalendarScreen(
         uiState = uiState,
         onCalendarDateClick = viewModel::updateSelectedDate,
-        onCalendarCardClick = {},
+        onCalendarCardClick = viewModel::onCalendarCardClick,
         onCalendarMonthChange = viewModel::calendar,
         modifier = modifier,
     )

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
@@ -32,6 +32,10 @@ class CalendarViewModel @Inject constructor(
     private var calendarJob: Job? = null
     private var calendarPostingsJob: Job? = null
 
+    init {
+        updateSelectedDate(LocalDate.now())
+    }
+
     fun updateSelectedDate(date: LocalDate) {
         _uiState.update { it.copy(selectedDate = date) }
         calendarPostings(date)

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
@@ -7,8 +7,10 @@ import com.haphap.app.data.repository.api.calendar.CalendarRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -24,12 +26,21 @@ class CalendarViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(CalendarContract.State())
     val uiState = _uiState.asStateFlow()
 
+    private val _sideEffect = Channel<CalendarContract.SideEffect>(Channel.BUFFERED)
+    val sideEffect = _sideEffect.receiveAsFlow()
+
     private var calendarJob: Job? = null
     private var calendarPostingsJob: Job? = null
 
     fun updateSelectedDate(date: LocalDate) {
         _uiState.update { it.copy(selectedDate = date) }
         calendarPostings(date)
+    }
+
+    fun onCalendarCardClick(postingId: Int) {
+        viewModelScope.launch {
+            _sideEffect.send(CalendarContract.SideEffect.NavigateToJobDetail(postingId))
+        }
     }
 
     fun calendar(yearMonth: YearMonth) {

--- a/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
@@ -22,9 +22,7 @@ fun NavGraphBuilder.calendarGraph(
 ) {
     composable<Calendar> {
         CalendarRoute(
-            navigateToJobDetail = { postingId ->
-                navController.navigateToJobDetail(postingId = postingId)
-            },
+            navigateToJobDetail = navController::navigateToJobDetail,
             modifier = Modifier.padding(innerPadding),
         )
     }

--- a/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.haphap.app.core.navigation.MainTabRoute
 import com.haphap.app.presentation.calendar.CalendarRoute
+import com.haphap.app.presentation.jobdetail.navigation.navigateToJobDetail
 import kotlinx.serialization.Serializable
 
 fun NavController.navigateToCalendar(
@@ -17,9 +18,13 @@ fun NavController.navigateToCalendar(
 
 fun NavGraphBuilder.calendarGraph(
     innerPadding: PaddingValues,
+    navController: NavController,
 ) {
     composable<Calendar> {
         CalendarRoute(
+            navigateToJobDetail = { postingId ->
+                navController.navigateToJobDetail(postingId = postingId)
+            },
             modifier = Modifier.padding(innerPadding),
         )
     }

--- a/app/src/main/java/com/haphap/app/presentation/home/HomeContract.kt
+++ b/app/src/main/java/com/haphap/app/presentation/home/HomeContract.kt
@@ -18,4 +18,10 @@ sealed interface HomeContract {
         val todayExpectedCardList: ImmutableList<TodayExpectedCardModel> = persistentListOf(),
         val categoryChipState: CategoryChipState = CategoryChipState(),
     )
+
+    sealed interface SideEffect {
+        data object NavigateToSearch : SideEffect
+        data object NavigateToJobList : SideEffect
+        data class NavigateToJobDetail(val postingId: Int) : SideEffect
+    }
 }

--- a/app/src/main/java/com/haphap/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/haphap/app/presentation/home/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,7 +21,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.haphap.app.R
 import com.haphap.app.core.designsystem.component.button.HapHapRefreshButton
 import com.haphap.app.core.designsystem.component.searchbar.HapHapSearchBar
@@ -42,17 +46,40 @@ fun HomeRoute(
     modifier: Modifier = Modifier,
     navigateToSearch: () -> Unit,
     navigateToJobList: () -> Unit,
+    navigateToJobDetail: (Int) -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.sideEffect.collect { sideEffect ->
+                when (sideEffect) {
+                    is HomeContract.SideEffect.NavigateToSearch -> {
+                        navigateToSearch()
+                    }
+
+                    is HomeContract.SideEffect.NavigateToJobList -> {
+                        navigateToJobList()
+                    }
+
+                    is HomeContract.SideEffect.NavigateToJobDetail -> {
+                        navigateToJobDetail(sideEffect.postingId)
+                    }
+                }
+            }
+        }
+    }
+
     HomeScreen(
         uiState = uiState,
-        onSearchBarClick = navigateToSearch,
-        onMoreClick = navigateToJobList,
+        onSearchBarClick = viewModel::onSearchBarClick,
+        onMoreClick = viewModel::onMoreClick,
         onFilterClick = { viewModel.updateSelectedChips(it) },
-        onRecentCardClick = {},
-        onListCardClick = {},
+        onRecentCardClick = viewModel::onCardClick,
+        onListCardClick = viewModel::onCardClick,
         onButtonClick = viewModel::onRefreshClick,
         modifier = modifier,
     )

--- a/app/src/main/java/com/haphap/app/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/home/HomeViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.haphap.app.data.repository.api.home.HomeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -19,6 +21,9 @@ class HomeViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(HomeContract.State())
     val uiState = _uiState.asStateFlow()
+
+    private val _sideEffect = Channel<HomeContract.SideEffect>()
+    val sideEffect = _sideEffect.receiveAsFlow()
 
     init {
         fetchAll()
@@ -72,13 +77,7 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun fetchRecentPostings() {
-        val selectedChips = _uiState.value.categoryChipState.selectedChips
-
-        val categoryParam = if (selectedChips.contains("전체")) {
-            null
-        } else {
-            selectedChips.toList()
-        }
+        val categoryParam = _uiState.value.categoryChipState.queryCategoryList
 
         viewModelScope.launch {
             homeRepository.getRecentPostings(categoryParam)
@@ -96,5 +95,17 @@ class HomeViewModel @Inject constructor(
             it.copy(categoryChipState = it.categoryChipState.toggle(category))
         }
         fetchRecentPostings()
+    }
+
+    fun onSearchBarClick() = viewModelScope.launch {
+        _sideEffect.send(HomeContract.SideEffect.NavigateToSearch)
+    }
+
+    fun onMoreClick() = viewModelScope.launch {
+        _sideEffect.send(HomeContract.SideEffect.NavigateToJobList)
+    }
+
+    fun onCardClick(postingId: Int) = viewModelScope.launch {
+        _sideEffect.send(HomeContract.SideEffect.NavigateToJobDetail(postingId))
     }
 }

--- a/app/src/main/java/com/haphap/app/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/home/navigation/HomeNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.haphap.app.core.navigation.MainTabRoute
 import com.haphap.app.presentation.home.HomeRoute
+import com.haphap.app.presentation.jobdetail.navigation.navigateToJobDetail
 import com.haphap.app.presentation.joblist.navigation.navigateToJobList
 import com.haphap.app.presentation.search.navigation.navigateToSearch
 import kotlinx.serialization.Serializable
@@ -25,6 +26,9 @@ fun NavGraphBuilder.homeGraph(
         HomeRoute(
             modifier = Modifier.padding(innerPadding),
             navigateToSearch = navController::navigateToSearch,
+            navigateToJobDetail = { postingId ->
+                navController.navigateToJobDetail(postingId = postingId)
+            },
             navigateToJobList = navController::navigateToJobList,
         )
     }

--- a/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.haphap.app.data.repository.api.detail.JobDetailRepository
+import com.haphap.app.data.repository.api.viewcount.ViewCountRepository
 import com.haphap.app.presentation.jobdetail.JobDetailContract.SideEffect.NavigateToRegister
 import com.haphap.app.presentation.jobdetail.JobDetailContract.SideEffect.OnShowToast
 import com.haphap.app.presentation.jobdetail.navigation.JobDetail
@@ -23,6 +24,7 @@ import timber.log.Timber
 class JobDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val jobDetailRepository: JobDetailRepository,
+    private val viewCountRepository: ViewCountRepository,
 ) : ViewModel() {
 
     private val postingId: Int = savedStateHandle.toRoute<JobDetail>().postingId
@@ -38,11 +40,21 @@ class JobDetailViewModel @Inject constructor(
         fetchJobPostingStages()
         fetchJobPostingStageStatuses()
         recordView()
+        viewCount()
+    }
+
+    private fun viewCount() {
+        viewModelScope.launch {
+            viewCountRepository.patchViewCount(postingId)
+                .onFailure { throwable ->
+                    Timber.e("$throwable 공고 조회 기록 실패했습니다.")
+                }
+        }
     }
 
     private fun recordView() {
         viewModelScope.launch {
-            jobDetailRepository.recordView(postingId)
+            viewCountRepository.patchRecordView(postingId)
                 .onFailure { throwable ->
                     Timber.e("$throwable 공고 조회 기록 실패했습니다.")
                 }

--- a/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
@@ -46,6 +46,9 @@ class JobDetailViewModel @Inject constructor(
     private fun viewCount() {
         viewModelScope.launch {
             viewCountRepository.patchViewCount(postingId)
+                .onSuccess { model ->
+                    Timber.e("$model 공고 조회 기록 성공했습니다.")
+                }
                 .onFailure { throwable ->
                     Timber.e("$throwable 공고 조회 기록 실패했습니다.")
                 }
@@ -55,6 +58,9 @@ class JobDetailViewModel @Inject constructor(
     private fun recordView() {
         viewModelScope.launch {
             viewCountRepository.patchRecordView(postingId)
+                .onSuccess { model ->
+                    Timber.e("$model 공고 조회 기록 성공했습니다.")
+                }
                 .onFailure { throwable ->
                     Timber.e("$throwable 공고 조회 기록 실패했습니다.")
                 }

--- a/app/src/main/java/com/haphap/app/presentation/joblist/JobListContract.kt
+++ b/app/src/main/java/com/haphap/app/presentation/joblist/JobListContract.kt
@@ -3,6 +3,7 @@ package com.haphap.app.presentation.joblist
 import androidx.compose.runtime.Immutable
 import com.haphap.app.data.model.list.JobItemModel
 import com.haphap.app.presentation.common.state.CategoryChipState
+import com.haphap.app.presentation.jobdetail.JobDetailUiState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -12,5 +13,16 @@ sealed interface JobListContract {
     data class State(
         val categoryChipState: CategoryChipState = CategoryChipState(),
         val jobList: ImmutableList<JobItemModel> = persistentListOf(),
+        val jobListUiState: JobListUiState = JobListUiState.Idle,
     )
+}
+
+sealed interface JobListUiState {
+    data object Idle : JobListUiState
+    data object Loading : JobListUiState
+    data object Empty : JobListUiState
+    data object Success : JobListUiState
+    data class Failure(
+        val msg: String,
+    ) : JobListUiState
 }

--- a/app/src/main/java/com/haphap/app/presentation/joblist/JobListScreen.kt
+++ b/app/src/main/java/com/haphap/app/presentation/joblist/JobListScreen.kt
@@ -7,10 +7,14 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridCells.Fixed
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.OutlinedTextFieldDefaults.contentPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,6 +27,7 @@ import com.haphap.app.core.designsystem.theme.HapHapTheme
 import com.haphap.app.core.designsystem.type.CardType
 import com.haphap.app.data.model.list.JobItemModel
 import com.haphap.app.presentation.common.component.HapHapCategoryChipList
+import com.haphap.app.presentation.joblist.component.IconEmptyComponent
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
@@ -31,9 +36,17 @@ fun JobListRoute(
     viewModel: JobListViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val gridState = rememberLazyGridState()
+
+    LaunchedEffect(
+        uiState.categoryChipState.selectedChips
+    ) {
+        gridState.scrollToItem(0)
+    }
 
     JobListScreen(
         uiState = uiState,
+        gridState = gridState,
         onSearchBarClick = {},
         onFilterClick = { viewModel.updateSelectedChips(it) },
         onCardClick = {},
@@ -44,6 +57,7 @@ fun JobListRoute(
 @Composable
 private fun JobListScreen(
     uiState: JobListContract.State,
+    gridState: LazyGridState,
     onSearchBarClick: () -> Unit,
     onFilterClick: (String) -> Unit,
     onCardClick: (Int) -> Unit,
@@ -69,28 +83,43 @@ private fun JobListScreen(
         )
 
         Spacer(modifier = Modifier.height(10.dp))
-        
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(2),
-            contentPadding = PaddingValues(vertical = 2.dp, horizontal = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            items(
-                items = uiState.jobList,
-                key = { it.id }
-            ) {
-                HapHapCard(
-                    type = CardType.SMALL,
-                    imageUrl = it.imageUrl,
-                    text = it.category,
-                    stage = it.stage,
-                    dDay = it.dDay,
-                    company = it.title,
-                    description = it.content,
-                    onCardClick = { onCardClick(it.id) },
+
+        when (uiState.jobListUiState) {
+            JobListUiState.Success -> {
+                LazyVerticalGrid(
+                    columns = Fixed(2),
+                    state = gridState,
+                    contentPadding = PaddingValues(vertical = 2.dp, horizontal = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    items(
+                        items = uiState.jobList,
+                        key = { it.id }
+                    ) {
+                        HapHapCard(
+                            type = CardType.SMALL,
+                            imageUrl = it.imageUrl,
+                            text = it.category,
+                            stage = it.stage,
+                            dDay = it.dDay,
+                            company = it.title,
+                            description = it.content,
+                            onCardClick = { onCardClick(it.id) },
+                        )
+                    }
+                }
+            }
+
+            JobListUiState.Empty -> {
+                IconEmptyComponent(
+                    text = "해당 카테고리에 등록된 공고가 없습니다",
+                    modifier = Modifier.padding(top = 190.dp),
                 )
             }
+
+            is JobListUiState.Failure, JobListUiState.Idle, JobListUiState.Loading -> {}
+
         }
     }
 }
@@ -141,6 +170,7 @@ private fun JobListScreenPreview() {
                     ),
                 )
             ),
+            gridState = rememberLazyGridState(),
             onSearchBarClick = {},
             onFilterClick = {},
             onCardClick = {},

--- a/app/src/main/java/com/haphap/app/presentation/joblist/JobListViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/joblist/JobListViewModel.kt
@@ -1,24 +1,56 @@
 package com.haphap.app.presentation.joblist
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.haphap.app.data.repository.api.JobListRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class JobListViewModel @Inject constructor(
-
-): ViewModel() {
+    private val jobListRepository: JobListRepository,
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(JobListContract.State())
     val uiState = _uiState.asStateFlow()
+
+    init {
+        getJobList()
+    }
 
     fun updateSelectedChips(category: String) {
         _uiState.update {
             it.copy(categoryChipState = it.categoryChipState.toggle(category))
         }
+        getJobList()
+    }
+
+    fun getJobList() = viewModelScope.launch {
+        _uiState.update { it.copy(jobListUiState = JobListUiState.Loading) }
+        val category = _uiState.value.categoryChipState.queryCategoryList
+        jobListRepository.getJobList(category = category)
+            .onSuccess { result ->
+                _uiState.update {
+                    it.copy(
+                        jobList = result.toImmutableList(),
+                        jobListUiState = if (result.isEmpty()) {
+                            JobListUiState.Empty
+                        } else {
+                            JobListUiState.Success
+                        }
+                    )
+                }
+            }
+            .onFailure { error ->
+                Timber.e("$error 공고 리스트 조회에 실패했습니다.")
+                _uiState.update { it.copy(jobListUiState = JobListUiState.Failure("$error")) }
+            }
     }
 
 }

--- a/app/src/main/java/com/haphap/app/presentation/joblist/component/IconEmptyComponent.kt
+++ b/app/src/main/java/com/haphap/app/presentation/joblist/component/IconEmptyComponent.kt
@@ -1,0 +1,52 @@
+package com.haphap.app.presentation.joblist.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.haphap.app.R
+import com.haphap.app.core.designsystem.theme.HapHapTheme
+
+@Composable
+fun IconEmptyComponent(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Column (
+        modifier = modifier
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_alert_53),
+            contentDescription = null,
+            tint = HapHapTheme.colors.gray200,
+        )
+
+        Text(
+            text = text,
+            color = HapHapTheme.colors.gray400,
+            style = HapHapTheme.typography.caption.sb12,
+        )
+    }
+
+}
+
+@Preview
+@Composable
+private fun IconEmptyComponentPreview() {
+    HapHapTheme{
+        IconEmptyComponent(
+            text = "해당 카테고리에 등록된 공고가 없습니다.",
+        )
+    }
+}

--- a/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
@@ -1,7 +1,8 @@
 package com.haphap.app.presentation.main
 
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
@@ -16,6 +17,8 @@ import com.haphap.app.presentation.register.navigation.registerGraph
 import com.haphap.app.presentation.search.navigation.searchGraph
 import com.haphap.app.presentation.splash.navigation.splashGraph
 
+private const val NavigationAnimationDurationMillis = 700
+
 @Composable
 fun MainNavHost(
     appState: MainAppState,
@@ -26,10 +29,8 @@ fun MainNavHost(
     NavHost(
         navController = navController,
         startDestination = appState.startDestination,
-        enterTransition = { EnterTransition.None },
-        exitTransition = { ExitTransition.None },
-        popEnterTransition = { EnterTransition.None },
-        popExitTransition = { ExitTransition.None },
+        enterTransition = { fadeIn(animationSpec = tween(NavigationAnimationDurationMillis)) },
+        exitTransition = { fadeOut(animationSpec = tween(NavigationAnimationDurationMillis)) },
     ) {
         splashGraph(
             innerPadding = innerPadding,
@@ -67,6 +68,7 @@ fun MainNavHost(
 
         calendarGraph(
             innerPadding = innerPadding,
+            navController = navController,
         )
 
         myPageGraph(

--- a/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
@@ -1,7 +1,8 @@
 package com.haphap.app.presentation.main
 
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
@@ -16,6 +17,8 @@ import com.haphap.app.presentation.register.navigation.registerGraph
 import com.haphap.app.presentation.search.navigation.searchGraph
 import com.haphap.app.presentation.splash.navigation.splashGraph
 
+private const val NavigationAnimationDurationMillis = 700
+
 @Composable
 fun MainNavHost(
     appState: MainAppState,
@@ -26,10 +29,8 @@ fun MainNavHost(
     NavHost(
         navController = navController,
         startDestination = appState.startDestination,
-        enterTransition = { EnterTransition.None },
-        exitTransition = { ExitTransition.None },
-        popEnterTransition = { EnterTransition.None },
-        popExitTransition = { ExitTransition.None },
+        enterTransition = { fadeIn(animationSpec = tween(NavigationAnimationDurationMillis)) },
+        exitTransition = { fadeOut(animationSpec = tween(NavigationAnimationDurationMillis)) },
     ) {
         splashGraph(
             innerPadding = innerPadding,

--- a/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
@@ -67,6 +67,7 @@ fun MainNavHost(
 
         calendarGraph(
             innerPadding = innerPadding,
+            navController = navController,
         )
 
         myPageGraph(


### PR DESCRIPTION
<!-- 제목 : [유형/#이슈번호] 작업 내용 (ex. "[UI/#6] 홈화면 구현") -->

## Related issue 🛠
<!-- 관련된 이슈 번호를 적어주셔야 pr이 머지될 때 해당 이슈가 자동으로 닫힙니다 -->
- closed #89

## Work Description ✏️
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->
- 캘린더 -> 디테일 네비 연결
- 화면전환 애니메이션


## Screenshot 📸

https://github.com/user-attachments/assets/9a151186-9cdb-41cf-b467-3f101930df4e


## Uncompleted Tasks 😅
- [ ] Task1


## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 홈/캘린더에서 공고 카드를 선택하면 공고 상세 화면으로 이동할 수 있습니다.
  - 내비게이션 같은 일회성 UI 동작이 화면 수명주기에 맞춰 안정적으로 처리됩니다.
- **개선 사항**
  - 화면 전환 애니메이션이 페이드 인·아웃으로 변경되었습니다.
  - 직무 목록에서 카테고리 선택 시 결과가 갱신되고, 로딩/빈/성공/실패 상태에 따라 그리드가 표시됩니다.
- **기타**
  - 잡 리스트 조회 및 데이터 변환 로직과 빈 상태 표시 컴포넌트가 추가되었습니다.
  - 조회수 기록 방식이 최신 엔드포인트로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->