### PR TITLE
[Feat/#89] calendar detail nav v2

### DIFF
--- a/app/src/main/java/com/haphap/app/data/remote/datasource/api/detail/JobDetailDataSource.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/api/detail/JobDetailDataSource.kt
@@ -18,6 +18,4 @@ interface JobDetailDataSource {
     suspend fun setAlarms(postingId: Int): BaseResponse<Unit>
 
     suspend fun deleteAlarms(postingId: Int): BaseResponse<Unit>
-
-    suspend fun recordView(postingId: Int)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
@@ -4,4 +4,6 @@ import com.haphap.app.data.remote.dto.BaseResponse
 
 interface ViewCountDataSource {
     suspend fun patchViewCount(postingId: Int): BaseResponse<Unit>
+
+    suspend fun patchRecordView(postingId: Int)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/api/viewcount/ViewCountDataSource.kt
@@ -5,5 +5,5 @@ import com.haphap.app.data.remote.dto.BaseResponse
 interface ViewCountDataSource {
     suspend fun patchViewCount(postingId: Int): BaseResponse<Unit>
 
-    suspend fun patchRecordView(postingId: Int)
+    suspend fun patchRecordView(postingId: Int): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/impl/detail/JobDetailDataSourceImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/impl/detail/JobDetailDataSourceImpl.kt
@@ -30,7 +30,4 @@ class JobDetailDataSourceImpl @Inject constructor(
 
     override suspend fun deleteAlarms(postingId: Int): BaseResponse<Unit> =
         jobDetailService.deleteAlarms(postingId)
-
-    override suspend fun recordView(postingId: Int) =
-        jobDetailService.recordView(postingId)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
@@ -11,4 +11,7 @@ class ViewCountDataSourceImpl @Inject constructor(
     override suspend fun patchViewCount(postingId: Int): BaseResponse<Unit> {
         return viewCountService.patchViewCount(postingId)
     }
+
+    override suspend fun patchRecordView(postingId: Int) =
+        viewCountService.patchRecordView(postingId)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/datasource/impl/viewcount/ViewCountDataSourceImpl.kt
@@ -12,6 +12,6 @@ class ViewCountDataSourceImpl @Inject constructor(
         return viewCountService.patchViewCount(postingId)
     }
 
-    override suspend fun patchRecordView(postingId: Int) =
+    override suspend fun patchRecordView(postingId: Int): BaseResponse<Unit> =
         viewCountService.patchRecordView(postingId)
 }

--- a/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
@@ -13,5 +13,5 @@ interface ViewCountService {
     @PATCH("api/v1/postings/{postingId}/views")
     suspend fun patchRecordView(
         @Path("postingId") postingId: Int,
-    )
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/service/ViewCountService.kt
@@ -9,4 +9,9 @@ interface ViewCountService {
     suspend fun patchViewCount(
         @Path("postingId") postingId: Int,
     ): BaseResponse<Unit>
+
+    @PATCH("api/v1/postings/{postingId}/views")
+    suspend fun patchRecordView(
+        @Path("postingId") postingId: Int,
+    )
 }

--- a/app/src/main/java/com/haphap/app/data/remote/service/detail/JobDetailService.kt
+++ b/app/src/main/java/com/haphap/app/data/remote/service/detail/JobDetailService.kt
@@ -7,7 +7,6 @@ import com.haphap.app.data.remote.dto.detail.JobDetailStageStatisticDto
 import com.haphap.app.data.remote.dto.detail.JobDetailStageStatusListDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -42,9 +41,4 @@ interface JobDetailService {
     suspend fun deleteAlarms(
         @Path("postingId") postingId: Int,
     ): BaseResponse<Unit>
-
-    @PATCH("api/v1/postings/{postingId}/views")
-    suspend fun recordView(
-        @Path("postingId") postingId: Int,
-    )
 }

--- a/app/src/main/java/com/haphap/app/data/repository/api/detail/JobDetailRepository.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/api/detail/JobDetailRepository.kt
@@ -17,6 +17,4 @@ interface JobDetailRepository {
     suspend fun setJobPostingAlarm(postingId: Int): Result<Unit>
 
     suspend fun deleteJobPostingAlarm(postingId: Int): Result<Unit>
-
-    suspend fun recordView(postingId: Int): Result<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/repository/api/viewcount/ViewCountRepository.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/api/viewcount/ViewCountRepository.kt
@@ -2,4 +2,6 @@ package com.haphap.app.data.repository.api.viewcount
 
 interface ViewCountRepository {
     suspend fun patchViewCount(postingId: Int): Result<Unit>
+
+    suspend fun patchRecordView(postingId: Int): Result<Unit>
 }

--- a/app/src/main/java/com/haphap/app/data/repository/impl/detail/JobDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/detail/JobDetailRepositoryImpl.kt
@@ -58,9 +58,4 @@ class JobDetailRepositoryImpl @Inject constructor(
             jobDetailDataSource.deleteAlarms(postingId).checkNullData()
             Unit
         }
-
-    override suspend fun recordView(postingId: Int): Result<Unit> =
-        suspendRunCatching {
-            jobDetailDataSource.recordView(postingId)
-        }
 }

--- a/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
@@ -13,4 +13,9 @@ class ViewCountRepositoryImpl @Inject constructor(
         suspendRunCatching {
             viewCountDataSource.patchViewCount(postingId).checkNullData()
         }
+
+    override suspend fun patchRecordView(postingId: Int): Result<Unit> =
+        suspendRunCatching {
+            viewCountDataSource.patchRecordView(postingId)
+        }
 }

--- a/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
+++ b/app/src/main/java/com/haphap/app/data/repository/impl/viewcount/ViewCountRepositoryImpl.kt
@@ -16,6 +16,6 @@ class ViewCountRepositoryImpl @Inject constructor(
 
     override suspend fun patchRecordView(postingId: Int): Result<Unit> =
         suspendRunCatching {
-            viewCountDataSource.patchRecordView(postingId)
+            viewCountDataSource.patchRecordView(postingId).checkNullData()
         }
 }

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarContract.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarContract.kt
@@ -16,6 +16,10 @@ sealed interface CalendarContract {
         val calendarUiState: CalendarUiState<List<CalendarModel>> = CalendarUiState.Idle,
         val calendarPostingsUiState: CalendarUiState<List<CalendarPostingModel>> = CalendarUiState.Idle,
     )
+
+    sealed class SideEffect {
+        data class NavigateToJobDetail(val postingId: Int) : SideEffect()
+    }
 }
 
 sealed interface CalendarUiState<out T> {

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarScreen.kt
@@ -10,15 +10,20 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.haphap.app.core.designsystem.theme.HapHapTheme
 import com.haphap.app.data.model.calendar.CalendarPostingModel
+import com.haphap.app.presentation.calendar.CalendarContract.SideEffect.NavigateToJobDetail
 import com.haphap.app.presentation.calendar.component.CalendarListCardComponent
 import com.haphap.app.presentation.calendar.component.CalendarListCardEmptyComponent
 import com.haphap.app.presentation.calendar.component.HapHapCustomCalendar
@@ -29,15 +34,27 @@ import java.time.YearMonth
 
 @Composable
 fun CalendarRoute(
+    navigateToJobDetail: (Int) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CalendarViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.sideEffect.collect { sideEffect ->
+                when (sideEffect) {
+                    is NavigateToJobDetail -> navigateToJobDetail(sideEffect.postingId)
+                }
+            }
+        }
+    }
 
     CalendarScreen(
         uiState = uiState,
         onCalendarDateClick = viewModel::updateSelectedDate,
-        onCalendarCardClick = {},
+        onCalendarCardClick = viewModel::onCalendarCardClick,
         onCalendarMonthChange = viewModel::calendar,
         modifier = modifier,
     )

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
@@ -32,6 +32,10 @@ class CalendarViewModel @Inject constructor(
     private var calendarJob: Job? = null
     private var calendarPostingsJob: Job? = null
 
+    init {
+        updateSelectedDate(LocalDate.now())
+    }
+
     fun updateSelectedDate(date: LocalDate) {
         _uiState.update { it.copy(selectedDate = date) }
         calendarPostings(date)

--- a/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/CalendarViewModel.kt
@@ -7,8 +7,10 @@ import com.haphap.app.data.repository.api.calendar.CalendarRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -24,12 +26,21 @@ class CalendarViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(CalendarContract.State())
     val uiState = _uiState.asStateFlow()
 
+    private val _sideEffect = Channel<CalendarContract.SideEffect>(Channel.BUFFERED)
+    val sideEffect = _sideEffect.receiveAsFlow()
+
     private var calendarJob: Job? = null
     private var calendarPostingsJob: Job? = null
 
     fun updateSelectedDate(date: LocalDate) {
         _uiState.update { it.copy(selectedDate = date) }
         calendarPostings(date)
+    }
+
+    fun onCalendarCardClick(postingId: Int) {
+        viewModelScope.launch {
+            _sideEffect.send(CalendarContract.SideEffect.NavigateToJobDetail(postingId))
+        }
     }
 
     fun calendar(yearMonth: YearMonth) {

--- a/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
@@ -22,9 +22,7 @@ fun NavGraphBuilder.calendarGraph(
 ) {
     composable<Calendar> {
         CalendarRoute(
-            navigateToJobDetail = { postingId ->
-                navController.navigateToJobDetail(postingId = postingId)
-            },
+            navigateToJobDetail = navController::navigateToJobDetail,
             modifier = Modifier.padding(innerPadding),
         )
     }

--- a/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
+++ b/app/src/main/java/com/haphap/app/presentation/calendar/navigation/CalendarNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.haphap.app.core.navigation.MainTabRoute
 import com.haphap.app.presentation.calendar.CalendarRoute
+import com.haphap.app.presentation.jobdetail.navigation.navigateToJobDetail
 import kotlinx.serialization.Serializable
 
 fun NavController.navigateToCalendar(
@@ -17,9 +18,13 @@ fun NavController.navigateToCalendar(
 
 fun NavGraphBuilder.calendarGraph(
     innerPadding: PaddingValues,
+    navController: NavController,
 ) {
     composable<Calendar> {
         CalendarRoute(
+            navigateToJobDetail = { postingId ->
+                navController.navigateToJobDetail(postingId = postingId)
+            },
             modifier = Modifier.padding(innerPadding),
         )
     }

--- a/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.haphap.app.data.repository.api.detail.JobDetailRepository
+import com.haphap.app.data.repository.api.viewcount.ViewCountRepository
 import com.haphap.app.presentation.jobdetail.JobDetailContract.SideEffect.NavigateToRegister
 import com.haphap.app.presentation.jobdetail.JobDetailContract.SideEffect.OnShowToast
 import com.haphap.app.presentation.jobdetail.navigation.JobDetail
@@ -23,6 +24,7 @@ import timber.log.Timber
 class JobDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val jobDetailRepository: JobDetailRepository,
+    private val viewCountRepository: ViewCountRepository,
 ) : ViewModel() {
 
     private val postingId: Int = savedStateHandle.toRoute<JobDetail>().postingId
@@ -38,11 +40,21 @@ class JobDetailViewModel @Inject constructor(
         fetchJobPostingStages()
         fetchJobPostingStageStatuses()
         recordView()
+        viewCount()
+    }
+
+    private fun viewCount() {
+        viewModelScope.launch {
+            viewCountRepository.patchViewCount(postingId)
+                .onFailure { throwable ->
+                    Timber.e("$throwable 공고 조회 기록 실패했습니다.")
+                }
+        }
     }
 
     private fun recordView() {
         viewModelScope.launch {
-            jobDetailRepository.recordView(postingId)
+            viewCountRepository.patchRecordView(postingId)
                 .onFailure { throwable ->
                     Timber.e("$throwable 공고 조회 기록 실패했습니다.")
                 }

--- a/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
+++ b/app/src/main/java/com/haphap/app/presentation/jobdetail/JobDetailViewModel.kt
@@ -46,6 +46,9 @@ class JobDetailViewModel @Inject constructor(
     private fun viewCount() {
         viewModelScope.launch {
             viewCountRepository.patchViewCount(postingId)
+                .onSuccess { model ->
+                    Timber.e("$model 공고 조회 기록 성공했습니다.")
+                }
                 .onFailure { throwable ->
                     Timber.e("$throwable 공고 조회 기록 실패했습니다.")
                 }
@@ -55,6 +58,9 @@ class JobDetailViewModel @Inject constructor(
     private fun recordView() {
         viewModelScope.launch {
             viewCountRepository.patchRecordView(postingId)
+                .onSuccess { model ->
+                    Timber.e("$model 공고 조회 기록 성공했습니다.")
+                }
                 .onFailure { throwable ->
                     Timber.e("$throwable 공고 조회 기록 실패했습니다.")
                 }

--- a/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/haphap/app/presentation/main/MainNavHost.kt
@@ -1,7 +1,8 @@
 package com.haphap.app.presentation.main
 
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
@@ -16,6 +17,8 @@ import com.haphap.app.presentation.register.navigation.registerGraph
 import com.haphap.app.presentation.search.navigation.searchGraph
 import com.haphap.app.presentation.splash.navigation.splashGraph
 
+private const val NavigationAnimationDurationMillis = 700
+
 @Composable
 fun MainNavHost(
     appState: MainAppState,
@@ -26,10 +29,8 @@ fun MainNavHost(
     NavHost(
         navController = navController,
         startDestination = appState.startDestination,
-        enterTransition = { EnterTransition.None },
-        exitTransition = { ExitTransition.None },
-        popEnterTransition = { EnterTransition.None },
-        popExitTransition = { ExitTransition.None },
+        enterTransition = { fadeIn(animationSpec = tween(NavigationAnimationDurationMillis)) },
+        exitTransition = { fadeOut(animationSpec = tween(NavigationAnimationDurationMillis)) },
     ) {
         splashGraph(
             innerPadding = innerPadding,
@@ -67,6 +68,7 @@ fun MainNavHost(
 
         calendarGraph(
             innerPadding = innerPadding,
+            navController = navController,
         )
 
         myPageGraph(


### PR DESCRIPTION
<!-- 제목 : [유형/#이슈번호] 작업 내용 (ex. "[UI/#6] 홈화면 구현") -->

## Related issue 🛠
<!-- 관련된 이슈 번호를 적어주셔야 pr이 머지될 때 해당 이슈가 자동으로 닫힙니다 -->
- closed #89

## Work Description ✏️
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->
- 캘린더 -> 디테일 네비 연결
- 화면전환 애니메이션


## Screenshot 📸

https://github.com/user-attachments/assets/9a151186-9cdb-41cf-b467-3f101930df4e


## Uncompleted Tasks 😅
- [ ] Task1


## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 홈/캘린더에서 공고 카드를 선택하면 공고 상세 화면으로 이동할 수 있습니다.
  - 내비게이션 같은 일회성 UI 동작이 화면 수명주기에 맞춰 안정적으로 처리됩니다.
- **개선 사항**
  - 화면 전환 애니메이션이 페이드 인·아웃으로 변경되었습니다.
  - 직무 목록에서 카테고리 선택 시 결과가 갱신되고, 로딩/빈/성공/실패 상태에 따라 그리드가 표시됩니다.
- **기타**
  - 잡 리스트 조회 및 데이터 변환 로직과 빈 상태 표시 컴포넌트가 추가되었습니다.
  - 조회수 기록 방식이 최신 엔드포인트로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->